### PR TITLE
fix: Fix typo in GithubCalendarComponent

### DIFF
--- a/app/components/pages/GithubCalendarComponent.tsx
+++ b/app/components/pages/GithubCalendarComponent.tsx
@@ -6,7 +6,7 @@ export default function GithubCalendarComponent() {
     <section>
       <Slide delay={0.16} className="mb-8">
         <h2 className="font-incognito text-4xl font-bold tracking-tight">
-          Contrbution Graph
+          Contribution Graph
         </h2>
       </Slide>
 


### PR DESCRIPTION
## Description 

Fix typo in the GithubCalendarComponent Heading `Contrbution` => `Contribution`

<img width="1098" alt="typo" src="https://github.com/user-attachments/assets/e82db507-0e7f-4f84-ae5f-e6e309bf55b1" />
